### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "b7b4119a-a378-4c5b-9837-fd9a8c690070",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Z3 locally",
+      "blurb": "Learn how to install Z3 locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "655543c8-30a2-4f12-a411-268a42a981ba",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Z3",
+      "blurb": "An overview of how to get started from scratch with Z3"
+    },
+    {
+      "uuid": "45a02cea-48ed-47b1-8d75-96ea627194f3",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Z3 track",
+      "blurb": "Learn how to test your Z3 exercises on Exercism"
+    },
+    {
+      "uuid": "44a4c9fc-313c-4fa6-8cd7-8e8b7c23592d",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Z3 resources",
+      "blurb": "A collection of useful resources to help you master Z3"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
