### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,9 +21,9 @@ jobs:
     runs-on: ubuntu-16.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Setup Python Dependencies
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
         with:
           python-version: 3.8
 
@@ -44,9 +44,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use ${{ matrix.version }}
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/pr.ci.yml
+++ b/.github/workflows/pr.ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Checkout PR
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
 
       - name: Use Node.js LTS (12.x)
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
         with:
           python-version: 3.8
 
@@ -42,9 +42,9 @@ jobs:
         python-version: [3.6, 3.7, 3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5
       - name: Use <setup tooling> ${{ matrix.version }}
-        uses: actions/setup-python@v2.2.2
+        uses: actions/setup-python@dc73133d4da04e56a135ae2246682783cc7c7cb6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.